### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,8 @@ RUN cd setup && \
     ./setup.sh && \
     cd .. && \
     chown -R $user:$user /home/$user/EyeWitness
+    mkdir -p /tmp/EyeWitness
 
 USER $user
 
 ENTRYPOINT ["python", "EyeWitness.py", "-d", "/tmp/EyeWitness/results", "--no-prompt"]
-


### PR DESCRIPTION
EyeWitness was complaining about the lack of the /tmp/EyeWitness directory ("[*] Error: Please provide a valid folder name/path") so the provided examples didn't work. 

Added `mkdir -p /tmp/EyeWitness` to solve this.