### PR TITLE
Added mkdir tmp\EyeWitness 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ WORKDIR /home/$user/EyeWitness
 RUN cd setup && \
     ./setup.sh && \
     cd .. && \
-    chown -R $user:$user /home/$user/EyeWitness
+    chown -R $user:$user /home/$user/EyeWitness \
     mkdir -p /tmp/EyeWitness
 
 USER $user

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,8 @@ RUN cd setup && \
     ./setup.sh && \
     cd .. && \
     chown -R $user:$user /home/$user/EyeWitness
+    mkdir -p /tmp/EyeWitness
 
 USER $user
 
 ENTRYPOINT ["python", "EyeWitness.py", "-d", "/tmp/EyeWitness/results", "--no-prompt"]
-


### PR DESCRIPTION
Eyewitness was complaining and the provided docker examples aren't working due to the lack of directory. 