### PR TITLE
Headless Update

### DIFF
--- a/EyeWitness.py
+++ b/EyeWitness.py
@@ -61,8 +61,6 @@ def create_cli_parser():
     protocols = parser.add_argument_group('Protocols')
     protocols.add_argument('--web', default=False, action='store_true',
                            help='HTTP Screenshot using Selenium')
-    protocols.add_argument('--headless', default=False, action='store_true',
-                           help='HTTP Screenshot using PhantomJS Headless')
     protocols.add_argument('--rdp', default=False, action='store_true',
                            help='Screenshot RDP Services')
     protocols.add_argument('--vnc', default=False, action='store_true',
@@ -145,7 +143,6 @@ def create_cli_parser():
                               "use (e.g. '80,8080')"))
     http_options.add_argument('--prepend-https', default=False, action='store_true',
                               help='Prepend http:// and https:// to URLs without either')
-    http_options.add_argument('--vhost-name', default=None,metavar='hostname', help='Hostname to use in Host header (headless + single mode only)')
     http_options.add_argument(
         '--active-scan', default=False, action='store_true',
         help='Perform live login attempts to identify credentials or login pages.')
@@ -208,19 +205,10 @@ def create_cli_parser():
         parser.print_help()
         sys.exit()
 
-    if not any((args.resume, args.web, args.vnc, args.rdp, args.all_protocols, args.headless)):
+    if not any((args.resume, args.web, args.vnc, args.rdp, args.all_protocols)):
         print "[*] Error: You didn't give me an action to perform."
         print "[*] Error: Please use --web, --rdp, or --vnc!\n"
         parser.print_help()
-        sys.exit()
-
-    if all((args.web, args.headless)):
-        print "[*] Error: Choose either web or headless"
-        parser.print_help()
-        sys.exit()
-
-    if args.vhost_name and not all((args.single, args.headless)):
-        print "[*] Error: vhostname can only be used in headless+single mode"
         sys.exit()
 
     if args.proxy_ip is not None and args.proxy_port is None:
@@ -255,18 +243,6 @@ def single_mode(cli_parsed):
         if not cli_parsed.show_selenium:
             display = Display(visible=0, size=(1920, 1080))
             display.start()
-    elif cli_parsed.headless:
-        if not os.path.isfile(
-            os.path.join(
-                os.path.dirname(
-                    os.path.realpath(__file__)
-                ), 'bin', 'phantomjs')
-        ):
-            print(" [*] Error: You are missing your phantomjs binary!")
-            print(" [*] Please run the setup script!")
-            sys.exit(0)
-        create_driver = phantomjs_module.create_driver
-        capture_host = phantomjs_module.capture_host
 
     url = cli_parsed.single
     http_object = objects.HTTPTableObject()
@@ -319,18 +295,7 @@ def worker_thread(cli_parsed, targets, lock, counter, user_agent=None):
     if cli_parsed.web:
         create_driver = selenium_module.create_driver
         capture_host = selenium_module.capture_host
-    elif cli_parsed.headless:
-        if not os.path.isfile(
-            os.path.join(
-                os.path.dirname(
-                    os.path.realpath(__file__)
-                ), 'bin', 'phantomjs')
-        ):
-            print(" [*] Error: You are missing your phantomjs binary!")
-            print(" [*] Please run the setup script!")
-            sys.exit(0)
-        create_driver = phantomjs_module.create_driver
-        capture_host = phantomjs_module.capture_host
+
     with lock:
         driver = create_driver(cli_parsed, user_agent)
     try:
@@ -453,7 +418,7 @@ def multi_mode(cli_parsed):
         pass
     else:
         url_list, rdp_list, vnc_list = target_creator(cli_parsed)
-        if any((cli_parsed.web, cli_parsed.headless)):
+        if cli_parsed.web:
             for url in url_list:
                 dbm.create_http_object(url, cli_parsed)
         for rdp in rdp_list:
@@ -461,7 +426,7 @@ def multi_mode(cli_parsed):
         for vnc in vnc_list:
             dbm.create_vnc_rdp_object('vnc', vnc, cli_parsed)
 
-    if any((cli_parsed.web, cli_parsed.headless)):
+    if cli_parsed.web:
         if cli_parsed.web and not cli_parsed.show_selenium:
             display = Display(visible=0, size=(1920, 1080))
             display.start()
@@ -610,8 +575,6 @@ if __name__ == "__main__":
         engines = []
         if cli_parsed.web:
             engines.append('Firefox')
-        if cli_parsed.headless:
-            engines.append('PhantomJS')
         if cli_parsed.vnc:
             engines.append('VNC')
         if cli_parsed.rdp:
@@ -627,7 +590,7 @@ if __name__ == "__main__":
         create_folders_css(cli_parsed)
 
     if cli_parsed.single:
-        if any((cli_parsed.web, cli_parsed.headless)):
+        if cli_parsed.web:
             single_mode(cli_parsed)
         elif cli_parsed.rdp:
             single_vnc_rdp(cli_parsed, 'rdp')

--- a/setup/setup.sh
+++ b/setup/setup.sh
@@ -58,7 +58,6 @@ case ${osinfo} in
     cd ../bin/
     MACHINE_TYPE=`uname -m`
     if [ ${MACHINE_TYPE} == 'x86_64' ]; then
-      wget -O phantomjs https://www.christophertruncer.com/InstallMe/kali2phantomjs
       wget https://github.com/mozilla/geckodriver/releases/download/v0.22.0/geckodriver-v0.22.0-linux64.tar.gz
       tar -xvf geckodriver-v0.22.0-linux64.tar.gz
       rm geckodriver-v0.22.0-linux64.tar.gz
@@ -66,7 +65,6 @@ case ${osinfo} in
       rm /usr/bin/geckodriver
       ln -s /usr/sbin/geckodriver /usr/bin/geckodriver
     else
-      wget -O phantomjs https://www.christophertruncer.com/InstallMe/phantom32kali2
       wget https://github.com/mozilla/geckodriver/releases/download/v0.22.0/geckodriver-v0.22.0-linux32.tar.gz
       tar -xvf geckodriver-v0.22.0-linux32.tar.gz
       rm geckodriver-v0.22.0-linux64.tar.gz
@@ -74,7 +72,6 @@ case ${osinfo} in
       rm /usr/bin/geckodriver
       ln -s /usr/sbin/geckodriver /usr/bin/geckodriver
     fi
-    chmod +x phantomjs
     cd ..
   ;;
   # Kali Dependency Installation
@@ -98,13 +95,6 @@ case ${osinfo} in
     pip install pyvirtualdisplay
     pip install pytesseract
     cd ../bin/
-    MACHINE_TYPE=`uname -m`
-    if [ ${MACHINE_TYPE} == 'x86_64' ]; then
-      wget -O phantomjs https://www.christophertruncer.com/InstallMe/phantomjs
-    else
-      wget -O phantomjs https://www.christophertruncer.com/InstallMe/kali32phantomjs
-    fi
-    chmod +x phantomjs
     cd ..
   ;;
    # Parrot Dependency Installation
@@ -128,13 +118,6 @@ case ${osinfo} in
     pip install pyvirtualdisplay
     pip install pytesseract
     cd ../bin/
-    MACHINE_TYPE=`uname -m`
-    if [ ${MACHINE_TYPE} == 'x86_64' ]; then
-      wget -O phantomjs https://www.christophertruncer.com/InstallMe/phantomjs
-    else
-      wget -O phantomjs https://www.christophertruncer.com/InstallMe/kali32phantomjs
-    fi
-    chmod +x phantomjs
     cd ..
   ;;
   # Debian 7+ Dependency Installation
@@ -164,33 +147,19 @@ case ${osinfo} in
     cd ../bin/
     MACHINE_TYPE=`uname -m`
     if [ ${MACHINE_TYPE} == 'x86_64' ]; then
-      wget --user-agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.116 Safari/537.36" https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2
       wget https://github.com/mozilla/geckodriver/releases/download/v0.22.0/geckodriver-v0.22.0-linux64.tar.gz
       tar -xvf geckodriver-v0.22.0-linux64.tar.gz
       rm geckodriver-v0.22.0-linux64.tar.gz
       mv geckodriver /usr/sbin
       rm /usr/bin/geckodriver
       ln -s /usr/sbin/geckodriver /usr/bin/geckodriver
-      tar -xvf phantomjs-2.1.1-linux-x86_64.tar.bz2
-      cd phantomjs-2.1.1-linux-x86_64/bin/
-      mv phantomjs ../../
-      cd ../..
-      rm -rf phantomjs-2.1.1-linux-x86_64
-      rm phantomjs-2.1.1-linux-x86_64.tar.bz2
     else
-      wget --user-agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.116 Safari/537.36" https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-i686.tar.bz2
       wget https://github.com/mozilla/geckodriver/releases/download/v0.22.0/geckodriver-v0.22.0-linux32.tar.gz
       tar -xvf geckodriver-v0.22.0-linux32.tar.gz
       rm geckodriver-v0.22.0-linux64.tar.gz
       mv geckodriver /usr/sbin
       rm /usr/bin/geckodriver
       ln -s /usr/sbin/geckodriver /usr/bin/geckodriver
-      tar -xvf phantomjs-2.1.1-linux-i686.tar.bz2
-      cd phantomjs-2.1.1-linux-i686/bin/
-      mv phantomjs ../../
-      cd ../..
-      rm -rf phantomjs-2.1.1-linux-i686
-      rm phantomjs-2.1.1-linux-i686.tar.bz2
     fi
     cd ..
   ;;
@@ -222,29 +191,15 @@ case ${osinfo} in
     cd ../bin/
     MACHINE_TYPE=`uname -m`
     if [ ${MACHINE_TYPE} == 'x86_64' ]; then
-      wget --user-agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.116 Safari/537.36" https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2
       wget https://github.com/mozilla/geckodriver/releases/download/v0.22.0/geckodriver-v0.22.0-linux64.tar.gz
       tar -xvf geckodriver-v0.22.0-linux64.tar.gz
       rm geckodriver-v0.22.0-linux64.tar.gz
       mv geckodriver /usr/sbin
-      tar -xvf phantomjs-2.1.1-linux-x86_64.tar.bz2
-      cd phantomjs-2.1.1-linux-x86_64/bin/
-      mv phantomjs ../../
-      cd ../..
-      rm -rf phantomjs-2.1.1-linux-x86_64
-      rm phantomjs-2.1.1-linux-x86_64.tar.bz2
     else
-      wget --user-agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.116 Safari/537.36" https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-i686.tar.bz2
       wget https://github.com/mozilla/geckodriver/releases/download/v0.22.0/geckodriver-v0.22.0-linux32.tar.gz
       tar -xvf geckodriver-v0.22.0-linux32.tar.gz
       rm geckodriver-v0.22.0-linux64.tar.gz
       mv geckodriver /usr/sbin
-      tar -xvf phantomjs-2.1.1-linux-i686.tar.bz2
-      cd phantomjs-2.1.1-linux-i686/bin/
-      mv phantomjs ../../
-      cd ../..
-      rm -rf phantomjs-2.1.1-linux-i686
-      rm phantomjs-2.1.1-linux-i686.tar.bz2
     fi
     cd ..
   ;;
@@ -280,24 +235,6 @@ case ${osinfo} in
     pip install pytesseract
     echo
     cd ../bin/
-    MACHINE_TYPE=`uname -m`
-    if [ ${MACHINE_TYPE} == 'x86_64' ]; then
-      wget --user-agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.116 Safari/537.36" https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2
-      tar -xvf phantomjs-2.1.1-linux-x86_64.tar.bz2
-      cd phantomjs-2.1.1-linux-x86_64/bin/
-      mv phantomjs ../../
-      cd ../..
-      rm -rf phantomjs-2.1.1-linux-x86_64
-      rm phantomjs-2.1.1-linux-x86_64.tar.bz2
-    else
-      wget --user-agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.116 Safari/537.36" https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-i686.tar.bz2
-      tar -xvf phantomjs-2.1.1-linux-i686.tar.bz2
-      cd phantomjs-2.1.1-linux-i686/bin/
-      mv phantomjs ../../
-      cd ../..
-      rm -rf phantomjs-2.1.1-linux-i686
-      rm phantomjs-2.1.1-linux-i686.tar.bz2
-    fi
     cd ..
   ;;
   # Notify Manual Installation Requirement And Exit


### PR DESCRIPTION
This pull request removes the "--headless" option from the command line menu. The only web option will now be --web. The --web parameter runs firefox, but it also runs it headlessly.

If on a server, you will need to install firefox, but then it will run headlessly.