### PR TITLE
fixing broken dependency "firefox-esr" for Ubuntu

### DIFF
--- a/setup/setup.sh
+++ b/setup/setup.sh
@@ -163,7 +163,7 @@ case ${osinfo} in
     fi
     cd ..
   ;;
-  # Ubuntu (tested in 13.10) Dependency Installation
+  # Ubuntu (tested in 16.04) Dependency Installation
   Ubuntu)
     apt-get update
     echo '[*] Installing Ubuntu Dependencies'

--- a/setup/setup.sh
+++ b/setup/setup.sh
@@ -167,7 +167,7 @@ case ${osinfo} in
   Ubuntu)
     apt-get update
     echo '[*] Installing Ubuntu Dependencies'
-    apt-get install -y cmake qt4-qmake python python-qt4 python-pip xvfb python-netaddr python-dev libffi-dev libssl-dev tesseract-ocr firefox-esr
+    apt-get install -y cmake qt4-qmake python python-qt4 python-pip xvfb python-netaddr python-dev libffi-dev libssl-dev tesseract-ocr firefox
     echo '[*] Installing RDPY'
     git clone https://github.com/ChrisTruncer/rdpy.git
     cd rdpy


### PR DESCRIPTION
AFAIK the package `firefox-esr` never existed in Canonicals repos:
https://packages.ubuntu.com/search?keywords=firefox-esr

Solves #372 