### PR TITLE
Fix report directory output permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,8 @@ RUN cd setup && \
     ./setup.sh && \
     cd .. && \
     chown -R $user:$user /home/$user/EyeWitness && \
-    mkdir -p /tmp/EyeWitness
+    mkdir -p /tmp/EyeWitness && \
+    chown $user:$user /tmp/EyeWitness
 
 USER $user
 


### PR DESCRIPTION
The Dockerfile ENTRYPOINT uses an output directory of "/tmp/EyeWitness/results", but "/tmp/EyeWitness" is only writable by root:root, not $user ("eyewitness"), so the "results" subdirectory can't be created, and EyeWitness will error.

A "chown" after directory creation fixes this.