### PR TITLE
CentOS : added python-devel to yum install fixes #401

### DIFF
--- a/setup/setup.sh
+++ b/setup/setup.sh
@@ -237,7 +237,7 @@ case ${osinfo} in
     fi
     echo '[*] Installing CentOS Dependencies'
     yum install cmake python python-pip PyQt4 PyQt4-webkit \
-                python-argparse xvfb python-netaddr python-dev tesseract-ocr firefox-esr python-devel
+                python-argparse xvfb python-netaddr python-devel tesseract-ocr firefox-esr
     echo
     echo '[*] Installing RDPY'
     git clone https://github.com/ChrisTruncer/rdpy.git

--- a/setup/setup.sh
+++ b/setup/setup.sh
@@ -237,7 +237,7 @@ case ${osinfo} in
     fi
     echo '[*] Installing CentOS Dependencies'
     yum install cmake python python-pip PyQt4 PyQt4-webkit \
-                python-argparse xvfb python-netaddr python-dev tesseract-ocr firefox-esr
+                python-argparse xvfb python-netaddr python-dev tesseract-ocr firefox-esr python-devel
     echo
     echo '[*] Installing RDPY'
     git clone https://github.com/ChrisTruncer/rdpy.git

--- a/setup/setup.sh
+++ b/setup/setup.sh
@@ -237,7 +237,7 @@ case ${osinfo} in
     fi
     echo '[*] Installing CentOS Dependencies'
     yum install cmake python python-pip PyQt4 PyQt4-webkit \
-                python-argparse xvfb python-netaddr python-devel tesseract-ocr firefox-esr
+                python-argparse xorg-x11-server-Xvfb python-netaddr python-devel tesseract firefox
     echo
     echo '[*] Installing RDPY'
     git clone https://github.com/ChrisTruncer/rdpy.git


### PR DESCRIPTION
In CentOS section of setup.sh

- added pyton-devel package to yum install  (python-dev existed but this is not a valid yum package, fixed #401 )

- Replaced incorrect yum packages with the correct yum packages xorg-x11-server-Xvfb, tesseract, firefox (fixes #403)

```
Transaction Summary
=======================================================================================================================================
Install  3 Packages (+38 Dependent packages)

Total download size: 134 M
Installed size: 346 M
Is this ok [y/d/N]: y
...
Installed:
  firefox.x86_64 0:60.7.0-1.el7.centos      tesseract.x86_64 0:3.04.00-3.el7      xorg-x11-server-Xvfb.x86_64 0:1.20.1-5.3.el7_6

Dependency Installed:
  adwaita-cursor-theme.noarch 0:3.28.0-1.el7                        adwaita-icon-theme.noarch 0:3.28.0-1.el7
  at-spi2-atk.x86_64 0:2.26.2-1.el7                                 at-spi2-core.x86_64 0:2.28.0-1.el7
  atk.x86_64 0:2.28.1-1.el7                                         cairo-gobject.x86_64 0:1.15.12-3.el7
  colord-libs.x86_64 0:1.3.4-1.el7                                  dconf.x86_64 0:0.28.0-4.el7

  .....

  Complete!

[*] Installing RDPY...............
```