### PR TITLE
Add handling for WebDriverException

### DIFF
--- a/modules/selenium_module.py
+++ b/modules/selenium_module.py
@@ -275,5 +275,7 @@ def capture_host(cli_parsed, http_object, driver, ua=None):
     except IOError:
         print("[*] ERROR: URL too long, surpasses max file length.")
         print("[*] ERROR: Skipping: " + http_object.remote_system)
+    except WebDriverException:
+        print("[*] ERROR: Skipping source code capture for: " + http_object.remote_system)
 
     return http_object, driver


### PR DESCRIPTION
In some cases, the driver raises an exception (which seems to come from Firefox's Marionnette according to the error message "curContainer.frame.document.documentElement is null") which is not captured.
It makes the current worker process dies, which is annoying when using the threads option, since the screenshotting continues, but with less processes...
My suggestion is to capture it and continue anyway.

Full error stacktrace:
```
Attempting to screenshot http://<redacted>
Process Process-6:
Traceback (most recent call last):
  File "/usr/lib/python2.7/multiprocessing/process.py", line 267, in _bootstrap
    self.run()
  File "/usr/lib/python2.7/multiprocessing/process.py", line 114, in run
    self._target(*self._args, **self._kwargs)
  File "EyeWitness/EyeWitness.py", line 337, in worker_thread
    cli_parsed, http_object, driver)
  File "/root/tools/EyeWitness/modules/selenium_module.py", line 268, in capture_host
    http_object.source_code = driver.page_source.encode('utf-8')
  File "/usr/local/lib/python2.7/dist-packages/selenium/webdriver/remote/webdriver.py", line 679, in page_source
    return self.execute(Command.GET_PAGE_SOURCE)['value']
  File "/usr/local/lib/python2.7/dist-packages/selenium/webdriver/remote/webdriver.py", line 321, in execute
    self.error_handler.check_response(response)
  File "/usr/local/lib/python2.7/dist-packages/selenium/webdriver/remote/errorhandler.py", line 242, in check_response
    raise exception_class(message, screen, stacktrace)
WebDriverException: Message: TypeError: curContainer.frame.document.documentElement is null
```