### PR TITLE
check if redhat release file exists before grepping it in setup script

### DIFF
--- a/setup/setup.sh
+++ b/setup/setup.sh
@@ -31,12 +31,13 @@ if [[ `(lsb_release -sd || grep ^PRETTY_NAME /etc/os-release) 2>/dev/null | grep
 fi
 
 # Centos detection
-if grep -q -i "CentOS" /etc/redhat-release
-then
-  osinfo="centos"
-  echo "[*] Centos detected"
+if test -f /etc/redhat-release; then
+  if grep -q -i "CentOS" /etc/redhat-release
+  then
+    osinfo="centos"
+    echo "[*] Centos detected"
+  fi
 fi
-
 
 # make sure we run from this directory
 pushd . > /dev/null && cd "$(dirname "$0")"


### PR DESCRIPTION
Without this, you get this error on boxes which aren't Redhat when running the setup script.

```
grep: /etc/redhat-release: No such file or directory
```