### PR TITLE
Python2 Setup Method Updates

### DIFF
--- a/setup/setup.sh
+++ b/setup/setup.sh
@@ -47,9 +47,9 @@ case ${osinfo} in
   Kali2)
     apt-get update
     echo '[*] Installing Kali2 Dependencies'
-    apt-get install -y cmake qt4-qmake python xvfb python-qt4 python-pip python-netaddr python-dev tesseract-ocr
+    apt-get install -y cmake qt4-qmake python xvfb python-qt4 python-python2 -m pip python-netaddr python-dev tesseract-ocr
     echo '[*] Upgrading paramiko'
-    pip install --upgrade paramiko
+    python2 -m pip install --upgrade paramiko
     echo '[*] Installing RDPY'
     git clone https://github.com/ChrisTruncer/rdpy.git
     cd rdpy
@@ -57,12 +57,13 @@ case ${osinfo} in
     cd ..
     rm -rf rdpy
     echo '[*] Installing Python Modules'
-    pip install fuzzywuzzy
-    pip install selenium --upgrade
-    pip install python-Levenshtein
-    pip install pyasn1 --upgrade
-    pip install pyvirtualdisplay
-    pip install pytesseract
+    python2 -m pip install fuzzywuzzy
+    python2 -m pip install selenium --upgrade
+    python2 -m pip install python-Levenshtein
+    python2 -m pip install pyasn1 --upgrade
+    python2 -m pip install pyvirtualdisplay
+    python2 -m pip install pytesseract
+    python2 -m pip install Pillow
     cd ../bin/
     MACHINE_TYPE=`uname -m`
     if [ ${MACHINE_TYPE} == 'x86_64' ]; then
@@ -92,9 +93,9 @@ case ${osinfo} in
   Kali)
     apt-get update
     echo '[*] Installing Kali Dependencies'
-    apt-get install -y python-qt4 python-pip xvfb python-netaddr python-dev tesseract-ocr
+    apt-get install -y python-qt4 python-python2 -m pip xvfb python-netaddr python-dev tesseract-ocr
     echo '[*] Upgrading paramiko'
-    pip install --upgrade paramiko
+    python2 -m pip install --upgrade paramiko
     echo '[*] Installing RDPY'
     git clone https://github.com/ChrisTruncer/rdpy.git
     cd rdpy
@@ -102,12 +103,12 @@ case ${osinfo} in
     cd ..
     rm -rf rdpy
     echo '[*] Installing Python Modules'
-    pip install fuzzywuzzy
-    pip install selenium --upgrade
-    pip install python-Levenshtein
-    pip install pyasn1 --upgrade
-    pip install pyvirtualdisplay
-    pip install pytesseract
+    python2 -m pip install fuzzywuzzy
+    python2 -m pip install selenium --upgrade
+    python2 -m pip install python-Levenshtein
+    python2 -m pip install pyasn1 --upgrade
+    python2 -m pip install pyvirtualdisplay
+    python2 -m pip install pytesseract
     cd ../bin/
     cd ..
   ;;
@@ -115,9 +116,9 @@ case ${osinfo} in
   Parrot)
     apt-get update
     echo '[*] Installing Parrot Dependencies'
-    apt-get install -y python-qt4 python-pip xvfb python-netaddr python-dev tesseract-ocr firefox-esr
+    apt-get install -y python-qt4 python-python2 -m pip xvfb python-netaddr python-dev tesseract-ocr firefox-esr
     echo '[*] Upgrading paramiko'
-    pip install --upgrade paramiko
+    python2 -m pip install --upgrade paramiko
     echo '[*] Installing RDPY'
     git clone https://github.com/ChrisTruncer/rdpy.git
     cd rdpy
@@ -125,12 +126,12 @@ case ${osinfo} in
     cd ..
     rm -rf rdpy
     echo '[*] Installing Python Modules'
-    pip install fuzzywuzzy
-    pip install selenium --upgrade
-    pip install python-Levenshtein
-    pip install pyasn1 --upgrade
-    pip install pyvirtualdisplay
-    pip install pytesseract
+    python2 -m pip install fuzzywuzzy
+    python2 -m pip install selenium --upgrade
+    python2 -m pip install python-Levenshtein
+    python2 -m pip install pyasn1 --upgrade
+    python2 -m pip install pyvirtualdisplay
+    python2 -m pip install pytesseract
     cd ../bin/
     cd ..
   ;;
@@ -138,10 +139,10 @@ case ${osinfo} in
   Debian)
     apt-get update
     echo '[*] Installing Debian Dependencies'
-    apt-get install -y cmake qt4-qmake python xvfb python-qt4 python-pip python-netaddr python-dev tesseract-ocr firefox-esr
+    apt-get install -y cmake qt4-qmake python xvfb python-qt4 python-python2 -m pip python-netaddr python-dev tesseract-ocr firefox-esr
     echo '[*] Upgrading paramiko and pyopenssl'
-    pip install --upgrade paramiko
-    pip install -U pyopenssl
+    python2 -m pip install --upgrade paramiko
+    python2 -m pip install -U pyopenssl
     echo '[*] Installing RDPY'
     git clone https://github.com/ChrisTruncer/rdpy.git
     cd rdpy
@@ -150,14 +151,14 @@ case ${osinfo} in
     rm -rf rdpy
     echo
     echo '[*] Installing Python Modules'
-    pip install python_qt_binding
-    pip install fuzzywuzzy
-    pip install selenium --upgrade
-    pip install python-Levenshtein
-    pip install pyasn1
-    pip install pyvirtualdisplay
-    pip install beautifulsoup4
-    pip install pytesseract
+    python2 -m pip install python_qt_binding
+    python2 -m pip install fuzzywuzzy
+    python2 -m pip install selenium --upgrade
+    python2 -m pip install python-Levenshtein
+    python2 -m pip install pyasn1
+    python2 -m pip install pyvirtualdisplay
+    python2 -m pip install beautifulsoup4
+    python2 -m pip install pytesseract
     echo
     cd ../bin/
     MACHINE_TYPE=`uname -m`
@@ -188,8 +189,8 @@ case ${osinfo} in
   Ubuntu)
     apt-get update
     echo '[*] Installing Ubuntu Dependencies'
-    apt-get install -y cmake qt4-qmake python python-qt4 python-pip xvfb python-netaddr python-dev libffi-dev libssl-dev tesseract-ocr firefox
-    pip install cryptography --upgrade
+    apt-get install -y cmake qt4-qmake python python-qt4 python-python2 -m pip xvfb python-netaddr python-dev libffi-dev libssl-dev tesseract-ocr firefox
+    python2 -m pip install cryptography --upgrade
     echo '[*] Installing RDPY'
     git clone https://github.com/ChrisTruncer/rdpy.git
     cd rdpy
@@ -198,17 +199,17 @@ case ${osinfo} in
     rm -rf rdpy
     echo
     echo '[*] Installing Python Modules'
-    pip install python_qt_binding
-    pip install fuzzywuzzy
-    pip install selenium --upgrade
-    pip install python-Levenshtein
-    pip install pyasn1
-    pip install pyvirtualdisplay
-    pip install beautifulsoup4
-    pip install pytesseract
-    pip install enum34
-    pip install ipaddress
-    pip install asn1crypto
+    python2 -m pip install python_qt_binding
+    python2 -m pip install fuzzywuzzy
+    python2 -m pip install selenium --upgrade
+    python2 -m pip install python-Levenshtein
+    python2 -m pip install pyasn1
+    python2 -m pip install pyvirtualdisplay
+    python2 -m pip install beautifulsoup4
+    python2 -m pip install pytesseract
+    python2 -m pip install enum34
+    python2 -m pip install ipaddress
+    python2 -m pip install asn1crypto
     echo
     cd ../bin/
     MACHINE_TYPE=`uname -m`
@@ -237,7 +238,7 @@ case ${osinfo} in
       exit 1
     fi
     echo '[*] Installing CentOS Dependencies'
-    yum install cmake python python-pip PyQt4 PyQt4-webkit \
+    yum install cmake python python-python2 -m pip PyQt4 PyQt4-webkit \
                 python-argparse xorg-x11-server-Xvfb python-netaddr python-devel tesseract firefox
     echo
     echo '[*] Installing RDPY'
@@ -247,14 +248,14 @@ case ${osinfo} in
     cd ..
     rm -rf rdpy
     echo '[*] Installing Python Modules'
-    pip install python_qt_binding
-    pip install fuzzywuzzy
-    pip install selenium --upgrade
-    pip install python-Levenshtein
-    pip install pyasn1
-    pip install pyvirtualdisplay
-    pip install beautifulsoup4
-    pip install pytesseract
+    python2 -m pip install python_qt_binding
+    python2 -m pip install fuzzywuzzy
+    python2 -m pip install selenium --upgrade
+    python2 -m pip install python-Levenshtein
+    python2 -m pip install pyasn1
+    python2 -m pip install pyvirtualdisplay
+    python2 -m pip install beautifulsoup4
+    python2 -m pip install pytesseract
     echo
     cd ../bin/
     cd ..

--- a/setup/setup.sh
+++ b/setup/setup.sh
@@ -47,7 +47,7 @@ case ${osinfo} in
   Kali2)
     apt-get update
     echo '[*] Installing Kali2 Dependencies'
-    apt-get install -y cmake qt4-qmake python xvfb python-qt4 python-python2 -m pip python-netaddr python-dev tesseract-ocr
+    apt-get install -y cmake qt4-qmake python xvfb python-qt4 python-pip python-netaddr python-dev tesseract-ocr
     echo '[*] Upgrading paramiko'
     python2 -m pip install --upgrade paramiko
     echo '[*] Installing RDPY'
@@ -93,7 +93,7 @@ case ${osinfo} in
   Kali)
     apt-get update
     echo '[*] Installing Kali Dependencies'
-    apt-get install -y python-qt4 python-python2 -m pip xvfb python-netaddr python-dev tesseract-ocr
+    apt-get install -y python-qt4 python-pip xvfb python-netaddr python-dev tesseract-ocr
     echo '[*] Upgrading paramiko'
     python2 -m pip install --upgrade paramiko
     echo '[*] Installing RDPY'
@@ -116,7 +116,7 @@ case ${osinfo} in
   Parrot)
     apt-get update
     echo '[*] Installing Parrot Dependencies'
-    apt-get install -y python-qt4 python-python2 -m pip xvfb python-netaddr python-dev tesseract-ocr firefox-esr
+    apt-get install -y python-qt4 python-pip xvfb python-netaddr python-dev tesseract-ocr firefox-esr
     echo '[*] Upgrading paramiko'
     python2 -m pip install --upgrade paramiko
     echo '[*] Installing RDPY'
@@ -139,7 +139,7 @@ case ${osinfo} in
   Debian)
     apt-get update
     echo '[*] Installing Debian Dependencies'
-    apt-get install -y cmake qt4-qmake python xvfb python-qt4 python-python2 -m pip python-netaddr python-dev tesseract-ocr firefox-esr
+    apt-get install -y cmake qt4-qmake python xvfb python-qt4 python-pip python-netaddr python-dev tesseract-ocr firefox-esr
     echo '[*] Upgrading paramiko and pyopenssl'
     python2 -m pip install --upgrade paramiko
     python2 -m pip install -U pyopenssl
@@ -189,7 +189,7 @@ case ${osinfo} in
   Ubuntu)
     apt-get update
     echo '[*] Installing Ubuntu Dependencies'
-    apt-get install -y cmake qt4-qmake python python-qt4 python-python2 -m pip xvfb python-netaddr python-dev libffi-dev libssl-dev tesseract-ocr firefox
+    apt-get install -y cmake qt4-qmake python python-qt4 python-pip xvfb python-netaddr python-dev libffi-dev libssl-dev tesseract-ocr firefox
     python2 -m pip install cryptography --upgrade
     echo '[*] Installing RDPY'
     git clone https://github.com/ChrisTruncer/rdpy.git
@@ -238,7 +238,7 @@ case ${osinfo} in
       exit 1
     fi
     echo '[*] Installing CentOS Dependencies'
-    yum install cmake python python-python2 -m pip PyQt4 PyQt4-webkit \
+    yum install cmake python python-pip PyQt4 PyQt4-webkit \
                 python-argparse xorg-x11-server-Xvfb python-netaddr python-devel tesseract firefox
     echo
     echo '[*] Installing RDPY'


### PR DESCRIPTION
The setup script in its current form does not distinguish pip against which python version packages are being installed for. In the case of Python2 branch, they should target `pip2` or `python2 -m pip`

The current implementation causes packages to be installed for whatever python version the user's local `pip` instance defaults. Usually this would be python2, but this is likely not going to be the case for long since python2 is deprecated, and pipy is following suit. In my case, `pip` targets python3.6, so it installed the dependencies for python3, but not python2 which is what I was trying to use.

It is better to be explicit and install via `python2 -m pip install` so that users aren't sent on a wild goose-chase trying to figure out why the EyeWitness.py script insists that packages are missing even though they ran the setup.sh script.

This change should probably be echoed in the master and Python3 branches as well

i.e. `python3 -m pip install <package>`

For that matter, the setup.sh script shouldn't even be using this method at all. It should be using pipenv or venv installation of packages, since it is safer for environments with multiple versions of python installed. At the very least, it should use the `pip install -r requirements` method with pinned versions so that the setup script doesn't break in the future, and can target the specific version of python for which the branch is intended.

For now, this PR contains my work-around to force installation via pip2.