### PR TITLE
Update docker build command in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Now you can execute EyeWitness in a docker container and prevent you from instal
 
 ##### Usage
 ```bash
-docker build --build-arg user=$USER --tag eyewitness .
+docker build --build-arg user=$USER --tag eyewitness --file ./Python/Dockerfile .
 docker run \
     --rm \
     -it \


### PR DESCRIPTION
The Dockerfile has been moved to a different directory (`./Python`)
I updated the command so users can execute it from within the root folder.