### PR TITLE
Fixed geckodriver variables

### DIFF
--- a/Python/setup/setup.sh
+++ b/Python/setup/setup.sh
@@ -5,8 +5,8 @@ userid=`id -u`
 osinfo=`cat /etc/issue|cut -d" " -f1|head -n1`
 distinfo=`cat /etc/issue|cut -d" " -f2|head -n1`
 eplpkg='http://linux.mirrors.es.net/fedora-epel/6/i386/epel-release-6-8.noarch.rpm'
-geckodriver_x86_64 = 'https://github.com/mozilla/geckodriver/releases/download/v0.26.0/geckodriver-v0.26.0-linux64.tar.gz'
-geckodriver_x86_32 = 'https://github.com/mozilla/geckodriver/releases/download/v0.26.0/geckodriver-v0.26.0-linux32.tar.gz'
+geckodriver_x86_64='https://github.com/mozilla/geckodriver/releases/download/v0.26.0/geckodriver-v0.26.0-linux64.tar.gz'
+geckodriver_x86_32='https://github.com/mozilla/geckodriver/releases/download/v0.26.0/geckodriver-v0.26.0-linux32.tar.gz'
 
 # Setting environment variables
 export TERM=linux


### PR DESCRIPTION
This simple PR fixes empty spaces in geckodriver variables declaration that give invalid url error (as the variable is not filled because of the space) during wget command: 
``` 
Try `wget --help' for more options.
tar: geckodriver-v0.26.0-linux64.tar.gz: Cannot open: No such file or directory
```