### PR TITLE
Add --selenium-log-path argument to handle Selenium geckodriver logs

### DIFF
--- a/Python/EyeWitness.py
+++ b/Python/EyeWitness.py
@@ -124,6 +124,8 @@ def create_cli_parser():
                               "use (e.g. '80,8080')"))
     http_options.add_argument('--prepend-https', default=False, action='store_true',
                               help='Prepend http:// and https:// to URLs without either')
+    http_options.add_argument('--selenium-log-path', default='./geckodriver.log', action='store',
+                              help='Selenium geckodriver log path')
 
     resume_options = parser.add_argument_group('Resume Options')
     resume_options.add_argument('--resume', metavar='ew.db',

--- a/Python/modules/selenium_module.py
+++ b/Python/modules/selenium_module.py
@@ -75,7 +75,7 @@ def create_driver(cli_parsed, user_agent=None):
         options = Options()
         options.add_argument("--headless")
         profile.update_preferences()
-        driver = webdriver.Firefox(profile, capabilities=capabilities, firefox_options=options)
+        driver = webdriver.Firefox(profile, capabilities=capabilities, firefox_options=options, service_log_path=cli_parsed.selenium_log_path)
         driver.set_page_load_timeout(cli_parsed.timeout)
         return driver
     except Exception as e:


### PR DESCRIPTION
**Feature**:
  - Add `--selenium-log-path` in Eyewitness CLI to handle Selenium geckodriver logs. For instance, they can be redirected to `/dev/null` if they are unwanted.

If I didn't respect some of your code requirements, be free to notice me.