### PR TITLE
Fix HTTPS service detection in Nmap XML

### DIFF
--- a/Python/modules/helpers.py
+++ b/Python/modules/helpers.py
@@ -66,13 +66,13 @@ class XML_Parser(xml.sax.ContentHandler):
             elif tag == "service":
                 if "ssl" in attributes['name'] or self.port_number in self.https_ports:
                     self.protocol = "https"
+                elif "tunnel" in attributes:
+                    if "ssl" in attributes['tunnel'] and not "smtp" in attributes['name'] and not "imap" in attributes['name'] and not "pop3" in attributes['name']:
+                        self.protocol = "https"
                 elif "http" == attributes['name'] or self.port_number in self.http_ports:
                     self.protocol = "http"
                 elif "http-alt" == attributes['name']:
                     self.protocol = "http"
-                elif "tunnel" in attributes:
-                    if "ssl" in attributes['tunnel'] and not "smtp" in attributes['name'] and not "imap" in attributes['name'] and not "pop3" in attributes['name']:
-                        self.protocol = "https"
             elif tag == "state":
                 if attributes['state'] == "open":
                     self.port_open = True


### PR DESCRIPTION
Here is an example XML output from Nmap for an HTTPS service on port 444:
```xml
<port protocol="tcp" portid="444">
<service name="http" product="Microsoft IIS httpd" version="10.0" ostype="Windows" tunnel="ssl" method="probed" conf="10">
</service>
```
With current code, this will generate an "http://" URL instead of "https://"

With this example, in terms of code, we have `attributes['name']` = `"http"` and `"ssl" in attributes['tunnel']` = `True`

With the current code, we have `elif "http" == attributes['name'] or self.port_number in self.http_ports:` that comes first and immediately returns "http" before the check of the "tunnel" attribute can happen.
So I moved it before :)