### PR TITLE
Update Dockerfile FROM line

### DIFF
--- a/Python/Dockerfile
+++ b/Python/Dockerfile
@@ -1,4 +1,4 @@
-FROM phusion/baseimage
+FROM phusion/baseimage:master-amd64
 LABEL maintainer Netanel Ravid
 
 ARG user=eyewitness


### PR DESCRIPTION
Appended platform-specific `:master-amd64` to the `FROM` line to get around build error (see below).

**Docker** warning:
```
$ sudo docker build -t fortynorthsecurity/eyewitness:latest .
Sending build context to Docker daemon  881.2kB
Step 1/11 : FROM phusion/baseimage
manifest for phusion/baseimage:latest not found: manifest unknown: manifest unknown
```

**VMware vctl** warning:
```
WARNING error in base image preparation: error while checking base image and local storage: failed to get the digest of image phusion/baseimage: GET https://index.docker.io/v2/phusion/baseimage/manifests/latest: MANIFEST_UNKNOWN: manifest unknown; map[Name:phusion/baseimage Revision:sha256:29479c37fcb28089eddd6619deed43bcdbcccf2185369e0199cc51a5ec78991b]; base images will be fetched from remote registry
```

VMware Fusion introduced the `vctl` command around v11.5 or so. As a side-comment specific to building Eyewitness on VMware Fusion, one tweak to the command line will get you around a likely error regarding running out of space. Since the build happens in memory, you may need to pass an additional argument to increase the amount allocated:
`vctl build --builder-mem 8192 -t fortynorthsecurity/eyewitness:latest .`