### PR TITLE
Improvements on the asynchronous code

### DIFF
--- a/CS/EyeWitness/Program.cs
+++ b/CS/EyeWitness/Program.cs
@@ -147,53 +147,53 @@ namespace EyeWitness
 
         private static async Task ScreenshotSender(WitnessedServer obj, int timeDelay)
         {
-            //Cancel after 30s
-            var cts = new CancellationTokenSource(timeDelay);
-            cts.CancelAfter(timeDelay);
             try
             {
                 //Keep it syncronous for this slow version
                 //Allow the thread to exit somewhat cleanly before exiting the semaphore
-                _pool.WaitOne(40000);
-
+                _pool.WaitOne();
+                //Cancel after timeDelay
+                var cts = new CancellationTokenSource(timeDelay);
                 Console.WriteLine("Grabbing screenshot for: " + obj.remoteSystem);
                 var task = await obj.RunWithTimeoutCancellation(cts.Token);
-
-                _pool.Release();
             }
-            catch (OperationCanceledException)
+            catch (OperationCanceledException e)
             {
-                Console.WriteLine("[-] Thread aborted while grabbing screenshot for: " + obj.remoteSystem);
+                Console.WriteLine($"[-] Thread aborted while grabbing screenshot for: {obj.remoteSystem} - {e.Message}");
             }
             catch (SemaphoreFullException)
             {
                 //return;
+            }
+            finally
+            {
+                _pool.Release();
             }
         }
 
         private static async Task SourceSender(WitnessedServer obj)
         {
-            //Cancel after 10s
-            //This cancellation time isn't as important as the screenshot one so we can hard code it
-            var cts = new CancellationTokenSource(10000);
-            cts.CancelAfter(10000);
-
             try
             {
-                await _Sourcepool.WaitAsync(10000);
+                await _Sourcepool.WaitAsync();
+                //Cancel after 10s
+                //This cancellation time isn't as important as the screenshot one so we can hard code it
+                var cts = new CancellationTokenSource(10000);
                 Console.WriteLine("Grabbing source of: " + obj.remoteSystem);
                 await obj.SourcerAsync(cts.Token);
                 obj.CheckCreds(categoryDict, signatureDict);
-
-                _Sourcepool.Release();
             }
-            catch (OperationCanceledException)
+            catch (OperationCanceledException e)
             {
-                Console.WriteLine("[-] Thread aborted while grabbing source for: " + obj.remoteSystem);
+                Console.WriteLine($"[-] Thread aborted while grabbing source for: {obj.remoteSystem} - {e.Message}");
             }
             catch (SemaphoreFullException)
             {
                 //return;
+            }
+            finally
+            {
+                _Sourcepool.Release();
             }
         }
 
@@ -205,7 +205,7 @@ namespace EyeWitness
                 if (categoryRankDict.ContainsKey(urlObject.systemCategory))
                 {
                     categoryRankDict[urlObject.systemCategory][1] = (int)categoryRankDict[urlObject.systemCategory][1] + 1;
-                }               
+                }
             }
         }
 
@@ -469,7 +469,13 @@ namespace EyeWitness
             int arrayPosition = 0;
             foreach (var url in allUrls)
             {
-                WitnessedServer singleSite = new WitnessedServer(url);
+                Uri uriResult;
+                if(!(Uri.TryCreate(url, UriKind.Absolute, out uriResult) && uriResult.Scheme == Uri.UriSchemeHttp))
+                {
+                    Uri.TryCreate($"http://{url}", UriKind.Absolute, out uriResult);
+                }
+
+                WitnessedServer singleSite = new WitnessedServer(uriResult.AbsoluteUri);
                 serverArray[arrayPosition] = singleSite;
                 arrayPosition++;
 

--- a/CS/EyeWitness/Program.cs
+++ b/CS/EyeWitness/Program.cs
@@ -470,7 +470,7 @@ namespace EyeWitness
             foreach (var url in allUrls)
             {
                 Uri uriResult;
-                if(!(Uri.TryCreate(url, UriKind.Absolute, out uriResult) && uriResult.Scheme == Uri.UriSchemeHttp))
+                if(!(Uri.TryCreate(url, UriKind.Absolute, out uriResult) && (uriResult.Scheme == Uri.UriSchemeHttp || uriResult.Scheme == Uri.UriSchemeHttps)))
                 {
                     Uri.TryCreate($"http://{url}", UriKind.Absolute, out uriResult);
                 }

--- a/CS/EyeWitness/WitnessedServer.cs
+++ b/CS/EyeWitness/WitnessedServer.cs
@@ -8,7 +8,6 @@ using System.Windows.Forms;
 using System.Text.RegularExpressions;
 using System.Collections.Generic;
 using System.Security;
-using System.ComponentModel;
 using System.Threading.Tasks;
 
 namespace EyeWitness
@@ -112,7 +111,6 @@ namespace EyeWitness
             catch(ThreadAbortException)
             {
                 Console.WriteLine("Error aborting thread, returning");
-                browser.Dispose();
                 return;
             }
             finally
@@ -209,43 +207,43 @@ namespace EyeWitness
 
             Thread workerThread = new Thread(delegate ()
             {
-                try
-                {
-                    //Create bounds the same size as the screen
-                    Rectangle bounds = Screen.PrimaryScreen.Bounds;
+                //Create bounds the same size as the screen
+                Rectangle bounds = Screen.PrimaryScreen.Bounds;
 
-                    //Don't care about TLS issues
-                    ServicePointManager.ServerCertificateValidationCallback = new RemoteCertificateValidationCallback
-                    (
-                        delegate { return true; }
-                    );
-                    using (WebBrowser br = new WebBrowser())
+                //Don't care about TLS issues
+                ServicePointManager.ServerCertificateValidationCallback = new RemoteCertificateValidationCallback
+                (
+                    delegate { return true; }
+                );
+                using (WebBrowser br = new WebBrowser())
+                {
+                    try
                     {
                         br.Width = bounds.Width;
                         br.Height = bounds.Height;
                         br.ScriptErrorsSuppressed = true;
                         br.ScrollBarsEnabled = false;
-
-
-                        br.Navigate(remoteSystem);
-
                         br.Visible = false;
                         br.DocumentCompleted += new WebBrowserDocumentCompletedEventHandler(DocumentCompleted);
                         br.NewWindow += new System.ComponentModel.CancelEventHandler(WinFormBrowser_NewWindow);
-
+                        
+                        br.Navigate(remoteSystem);
 
                         while (br.ReadyState != WebBrowserReadyState.Complete)
                         {
                             System.Windows.Forms.Application.DoEvents();
-                            //Application.Run();
+                            cancellationToken.ThrowIfCancellationRequested();
+                        }
+                    }
+                    catch { }
+                    finally
+                    {
+                        if(!br.IsDisposed)
+                        {
+                            br.Dispose();
                         }
                     }
                 }
-                catch
-                {
-                    return;
-                }
-
             });
             workerThread.SetApartmentState(ApartmentState.STA);
             await Task.Run(() =>
@@ -282,14 +280,11 @@ namespace EyeWitness
             // Capture source code and headers
             ServicePointManager.Expect100Continue = true;
             // fix for allowing tls12
-            ServicePointManager.SecurityProtocol = (SecurityProtocolType)3072;
+            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
             await Task.Run(async() =>
             {
                 using (WebClient witnessClient = new WebClient())
                 {
-                    // Instantiate the CancellationTokenSource.
-                    //var taskCompletionSource = new TaskCompletionSource<bool>();
-                    //cts.CancelAfter(20000);
 
                     try
                     {
@@ -298,25 +293,27 @@ namespace EyeWitness
                                 delegate { return true; }
                             );
                         // Uri test = Uri.Parse(remoteSystem);
-                        sourceCode = witnessClient.DownloadString(remoteSystem);
+                        cancellationToken.Register(witnessClient.CancelAsync);
+                        sourceCode = await witnessClient.DownloadStringTaskAsync(remoteSystem);
+                        cancellationToken.ThrowIfCancellationRequested();
                         headers = witnessClient.ResponseHeaders.ToString();
                         webpageTitle = Regex.Match(sourceCode, @"\<title\b[^>]*\>\s*(?<Title>[\s\S]*?)\</title\>",
                                        RegexOptions.IgnoreCase).Groups["Title"].Value;
                         File.WriteAllText(Program.witnessDir + "\\src\\" + urlSaveName + ".txt", sourceCode);
                         File.WriteAllText(Program.witnessDir + "\\headers\\" + urlSaveName + ".txt", headers);
-                        witnessClient.Dispose();
-                        return;
                     }
-
                     catch (Exception e)
                     {
                         //Console.WriteLine(e);
-                        Console.WriteLine("[*] Offline Server - " + remoteSystem);
+                        Console.WriteLine($"[*] Offline Server - {remoteSystem} - {e.Message}");
                         errorState = "offline";
                         systemCategory = "offline";
                         webpageTitle = "Server Offline";
                         headers = "Server Offline";
-                        return;
+                    }
+                    finally
+                    {
+                        witnessClient.Dispose();
                     }
                 }
             }, cancellationToken);

--- a/CS/EyeWitness/WitnessedServer.cs
+++ b/CS/EyeWitness/WitnessedServer.cs
@@ -249,7 +249,7 @@ namespace EyeWitness
             await Task.Run(() =>
             {
                 workerThread.Start();
-                bool finished = workerThread.Join(30000);
+                bool finished = workerThread.Join(Timeout.Infinite);
                 if (!finished)
                     try
                     {


### PR DESCRIPTION
I had some bugs where the task would time out even though it was just started.

The changes in here mainly fix the order of acquiring the lock/semaphore before creating the cancellationToken. This also allowed to do the source code grabbing asynchronously as well.

There is some extra code in there that allows to pass domains to the tool instead of only URLs. I hope this is also a worthy addition.
