### PR TITLE
Fix for #471 "the windows client can't fire up" -  Force TLS v1.2

### DIFF
--- a/CS/EyeWitness/Program.cs
+++ b/CS/EyeWitness/Program.cs
@@ -77,16 +77,20 @@ namespace EyeWitness
         {
             // Capture category and signature codes
             // Grab here so we only have to do it once and iterate through URLs in Main
+            // Set TLS v1.2
+			ServicePointManager.Expect100Continue = true;
+            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
             WebClient witnessClient = new WebClient();
             try
             {
                 catCode = witnessClient.DownloadString(catURL);
                 sigCode = witnessClient.DownloadString(sigURL);
             }
-            catch
+            catch(Exception ex)
             {
                 Console.WriteLine("[*]ERROR: Could not obtain categories and signatures from Github!");
                 Console.WriteLine("[*]ERROR: Try again, or see if Github is blocked?");
+                Console.WriteLine(ex.Message);
                 System.Environment.Exit(1);
             }
 


### PR DESCRIPTION
Force TLS v1.2 and add better exception logging for this problem