### PR TITLE
Add AttributeError exception to allow manual scan completion

### DIFF
--- a/Python/modules/objects.py
+++ b/Python/modules/objects.py
@@ -238,6 +238,9 @@ class HTTPTableObject(object):
             try:
                 html += "\n<br><b> Page Title: </b>{0}\n".format(
                     self.sanitize(self.page_title))
+            except AttributeError:
+                html += "\n<br><b> Page Title:</b>{0}\n".format(
+                    'Unable to Display')
             except UnicodeDecodeError:
                 html += "\n<br><b> Page Title:</b>{0}\n".format(
                     'Unable to Display')
@@ -408,6 +411,9 @@ class UAObject(HTTPTableObject):
         try:
             html += "\n<br><b> Page Title: </b>{0}\n".format(
                 self.sanitize(self.page_title))
+        except AttributeError:
+            html += "\n<br><b> Page Title:</b>{0}\n".format(
+                'Unable to Display')
         except UnicodeDecodeError:
             html += "\n<br><b> Page Title:</b>{0}\n".format(
                 'Unable to Display')


### PR DESCRIPTION
Sorry this took me so long! It's been a crazy year all around...

Closes #520 

Allows for the manual completion of EyeWitness scans via sqlite database manipulation. Adding the AttributeError mitigates NoneType exceptions after marking hosts as complete. Had to be added in two places to get working.

Future reference for anybody who stumbles upon this issue (until I or anybody else identifies what causes this issue):

Connect to the database file and run the following query: `UPDATE http SET complete = 1 WHERE complete = 0;`

Resume EyeWitness and the scan should complete.