### PR TITLE
Add setup & docker support for Cent0S 7 and Rocky Linux 8

### DIFF
--- a/Python/Dockerfile.el7
+++ b/Python/Dockerfile.el7
@@ -1,0 +1,35 @@
+FROM centos:centos7
+LABEL maintainer ???
+
+ARG USER=eyewitness
+ARG UID=1000
+ARG GID=1000
+
+ENV LC_ALL=en_US.UTF-8 \
+    LANG=en_US.UTF-8 \
+    PYTHONUNBUFFERED=1 \
+    PYTHONIOENCODING=UTF-8 \
+    PIP_NO_CACHE_DIR=off
+
+RUN groupadd -g $GID -r $USER && \
+    useradd $USER -u $UID -g $USER -m
+
+COPY setup.sh /tmp/setup.sh
+
+RUN yum install -y git && \
+    git clone --depth 1 https://github.com/FortyNorthSecurity/EyeWitness.git /home/$USER/EyeWitness && \
+    cp /tmp/setup.sh /home/$USER/EyeWitness/Python/setup/setup.sh && \
+    yum remove -y git
+
+WORKDIR /home/$USER/EyeWitness
+
+RUN cd Python/setup && \
+    ./setup.sh && \
+    cd .. && \
+    chown -R $USER:$USER /home/$USER/EyeWitness && \
+    mkdir -p /tmp/EyeWitness && \
+    chown $USER:$USER /tmp/EyeWitness
+
+USER $USER
+
+ENTRYPOINT ["python3", "Python/EyeWitness.py", "-d", "/tmp/EyeWitness/results", "--no-prompt"]

--- a/Python/Dockerfile.el8
+++ b/Python/Dockerfile.el8
@@ -1,0 +1,35 @@
+FROM rockylinux:8
+LABEL maintainer ???
+
+ARG USER=eyewitness
+ARG UID=1000
+ARG GID=1000
+
+ENV LC_ALL=C.UTF-8 \
+    LANG=C.UTF-8 \
+    PYTHONUNBUFFERED=1 \
+    PYTHONIOENCODING=UTF-8 \
+    PIP_NO_CACHE_DIR=off
+
+RUN groupadd -g $GID -r $USER && \
+    useradd $USER -u $UID -g $USER -m
+
+COPY setup.sh /tmp/setup.sh
+
+RUN dnf install -y git && \
+    git clone --depth 1 https://github.com/FortyNorthSecurity/EyeWitness.git /home/$USER/EyeWitness && \
+    cp /tmp/setup.sh /home/$USER/EyeWitness/Python/setup/setup.sh && \
+    dnf remove -y git
+
+WORKDIR /home/$USER/EyeWitness
+
+RUN cd Python/setup && \
+    ./setup.sh && \
+    cd .. && \
+    chown -R $USER:$USER /home/$USER/EyeWitness && \
+    mkdir -p /tmp/EyeWitness && \
+    chown $USER:$USER /tmp/EyeWitness
+
+USER $USER
+
+ENTRYPOINT ["python3", "Python/EyeWitness.py", "-d", "/tmp/EyeWitness/results", "--no-prompt"]

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ EyeWitness.exe --file C:\Path\to\urls.txt --delay [timeout in seconds] --compres
 ###### Supported Linux Distros:
 * Kali Linux
 * Debian 7+ (at least stable, looking into testing) (Thanks to @themightyshiv)
+* CentOS 7
+* Rocky Linux 8
 
 **E-Mail:** EyeWitness [@] christophertruncer [dot] com
 


### PR DESCRIPTION
Hello,

I worked to add setup support for CentOS 7 and Rocky Linux 8 and associated Dockerfile. As such, it can be used standalone by anyone interested but also for testing of the setup process for the two distributions.

I also updated the documentation to reflect this change.

Only point to not adequately set is the maintainer label in both Dockerfile. I currently put ???. You can change it to your convenience.

Hope it can be merge quickly :)

Best regards.