### PR TITLE
Adding back the CIDR option 

### DIFF
--- a/CS/EyeWitness/EyeWitness.csproj
+++ b/CS/EyeWitness/EyeWitness.csproj
@@ -56,17 +56,30 @@
     <Reference Include="Costura, Version=4.1.0.0, Culture=neutral, PublicKeyToken=9919ef960d84173d, processorArchitecture=MSIL">
       <HintPath>..\packages\Costura.Fody.4.1.0\lib\net40\Costura.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.CSharp" />
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Activities" />
+    <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Buffers.4.5.1\lib\netstandard1.1\System.Buffers.dll</HintPath>
+    </Reference>
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.IO.Compression" />
     <Reference Include="System.IO.Compression.FileSystem" />
+    <Reference Include="System.Memory, Version=4.0.1.2, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Memory.4.5.5\lib\netstandard1.1\System.Memory.dll</HintPath>
+    </Reference>
     <Reference Include="System.Net" />
+    <Reference Include="System.Net.IPNetwork, Version=2.6.427.0, Culture=neutral, PublicKeyToken=717343cc2c25edcf, processorArchitecture=MSIL">
+      <HintPath>..\packages\IPNetwork2.2.6.427\lib\net45\System.Net.IPNetwork.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.4.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.5.3\lib\netstandard1.0\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    </Reference>
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/CS/EyeWitness/Program.cs
+++ b/CS/EyeWitness/Program.cs
@@ -41,6 +41,9 @@ namespace EyeWitness
             [Option('f', "file", Group = "Input Source", HelpText = "Specify a new-line separated file of URLs", Default = null)]
             public string File { get; set; }
 
+            [Option('i', "cidr", Group = "Input Source", HelpText = "Specify an IP CIDR", Default = null)]
+            public string IpAddresses { get; set; }
+
             [Option('o', "output", Required = false, HelpText = "Specify an output directory (one will be created if non-existent)", Default = null)]
             public string Output { get; set; }
 
@@ -505,6 +508,30 @@ namespace EyeWitness
                             Console.WriteLine("[-] ERROR: The file containing the URLS to scan does not exist!");
                             Console.WriteLine("[-] ERROR: Please make sure you've provided the correct filepath and try again.");
                             System.Environment.Exit(1);
+                        }
+                    }
+
+                    if (o.IpAddresses != null)
+                    {
+                        Console.WriteLine("[+] Using IP addresses");
+
+                        try
+                        {
+                            if (!IPNetwork.TryParse(o.IpAddresses, out var parsed))
+                            {
+                                Console.WriteLine("[-] ERROR: Failed to parse IP Addresses");
+                                return;
+                            }
+
+                            var ipAddress = parsed.ListIPAddress().Distinct().ToList();
+                            var strings = new List<string>();
+                            ipAddress.ForEach(i => strings.Add(i.ToString()));
+                            allUrls = strings.ToArray();
+                        }
+                        catch (Exception e)
+                        {
+                            Console.WriteLine($"[-] ERROR: {e.Message}");
+                            return;
                         }
                     }
 

--- a/CS/EyeWitness/app.config
+++ b/CS/EyeWitness/app.config
@@ -3,4 +3,12 @@
   <startup>
     <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
   </startup>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
 </configuration>

--- a/CS/EyeWitness/packages.config
+++ b/CS/EyeWitness/packages.config
@@ -3,5 +3,9 @@
   <package id="CommandLineParser" version="2.7.82" targetFramework="net45" />
   <package id="Costura.Fody" version="4.1.0" targetFramework="net45" />
   <package id="Fody" version="6.1.1" targetFramework="net45" developmentDependency="true" />
+  <package id="IPNetwork2" version="2.6.427" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net45" />
+  <package id="System.Buffers" version="4.5.1" targetFramework="net45" />
+  <package id="System.Memory" version="4.5.5" targetFramework="net45" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.3" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
This option is super useful but got clobbered by the reversion in c2fbef5c797349eb92b0d17ea0e35f06fbdfc6c8. It looks like when the change was originally added, it was set to target .NET Framework 4.8 when the rest of the project was targeting 4.5. I updated the package configs so that everything runs on 4.5 now and the pipeline should pass 🤞